### PR TITLE
Make the 	Content-Range header configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,11 @@ function Upload (cfg) {
   this.numBytesWritten = 0
   this.numRetries = 0
 
-  cfg.offset = parseInt(cfg.offset, 10);
-  cfg.offset = isNaN(cfg.offset) ? 0 : cfg.offset;
+  cfg.offset = parseInt(cfg.offset, 10)
+  cfg.offset = isNaN(cfg.offset) ? 0 : cfg.offset
 
-  var contentLength = cfg.metadata ? parseInt(cfg.metadata.contentLength, 10) : NaN;
-  this.contentLength = isNaN(contentLength) ? '*' : contentLength;
+  var contentLength = cfg.metadata ? parseInt(cfg.metadata.contentLength, 10) : NaN
+  this.contentLength = isNaN(contentLength) ? '*' : contentLength
 
   this.once('writing', function () {
     if (self.uri) {

--- a/index.js
+++ b/index.js
@@ -55,6 +55,12 @@ function Upload (cfg) {
   this.numBytesWritten = 0
   this.numRetries = 0
 
+  cfg.offset = parseInt(cfg.offset, 10);
+  cfg.offset = isNaN(cfg.offset) ? 0 : cfg.offset;
+
+  var contentLength = cfg.metadata ? parseInt(cfg.metadata.contentLength, 10) : NaN;
+  this.contentLength = isNaN(contentLength) ? '*' : contentLength;
+
   this.once('writing', function () {
     if (self.uri) {
       self.continueUploading()
@@ -63,7 +69,7 @@ function Upload (cfg) {
         if (err) return self.destroy(err)
         self.uri = uri
         self.set({ uri: uri })
-        self.offset = 0
+        self.offset = cfg.offset
         self.startUploading()
       })
     }
@@ -128,7 +134,7 @@ Upload.prototype.startUploading = function () {
     method: 'PUT',
     uri: this.uri,
     headers: {
-      'Content-Range': 'bytes ' + this.offset + '-*/*'
+      'Content-Range': 'bytes ' + this.offset + '-*/' + this.contentLength
     }
   }
 

--- a/readme.md
+++ b/readme.md
@@ -145,6 +145,13 @@ Make the uploaded file public. (Alias for `config.predefinedAcl = 'publicRead'`)
 
 If you already have a resumable URI from a previously-created resumable upload, just pass it in here and we'll use that.
 
+###### config.offset
+
+- Type: `number`
+- *Optional*
+
+The starting byte of the upload stream, for [resuming an interrupted upload](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#resume-upload).
+
 --
 
 #### Events

--- a/test.js
+++ b/test.js
@@ -402,7 +402,7 @@ describe('gcs-resumable-upload', function () {
         assert.strictEqual(reqOpts.method, 'PUT')
         assert.strictEqual(reqOpts.uri, up.uri)
         assert.deepEqual(reqOpts.headers, {
-          'Content-Range': 'bytes ' + OFFSET + '-*/*'
+          'Content-Range': 'bytes ' + OFFSET + '-*/' + up.contentLength
         })
 
         done()

--- a/test.js
+++ b/test.js
@@ -215,6 +215,16 @@ describe('gcs-resumable-upload', function () {
       assert.strictEqual(up.numRetries, 0)
     })
 
+    it('should set the contentLength if provided', function () {
+      var up = upload({ bucket: BUCKET, file: FILE, metadata: { contentLength: METADATA.contentLength } })
+      assert.strictEqual(up.contentLength, METADATA.contentLength)
+    })
+
+    it('should default the contentLength to *', function () {
+      var up = upload({ bucket: BUCKET, file: FILE })
+      assert.strictEqual(up.contentLength, '*')
+    })
+
     it('should localize the uri or get one from config', function () {
       var uri = 'http://www.blah.com/'
       var upWithUri = upload({ bucket: BUCKET, file: FILE, uri: uri })

--- a/test.js
+++ b/test.js
@@ -287,9 +287,24 @@ describe('gcs-resumable-upload', function () {
         up.emit('writing')
       })
 
-      it('should set the offset 0', function (done) {
+      it('should default the offset to 0', function (done) {
         up.startUploading = function () {
           assert.strictEqual(up.offset, 0)
+          done()
+        }
+
+        up.createURI = function (callback) {
+          callback(null, URI)
+        }
+
+        up.emit('writing')
+      })
+
+      it('should set the offset if it is provided', function (done) {
+        var OFFSET = 10
+        var up = upload({ bucket: BUCKET, file: FILE, offset: OFFSET })
+        up.startUploading = function () {
+          assert.strictEqual(up.offset, OFFSET)
           done()
         }
 


### PR DESCRIPTION
The JSON api supports [resuming an interrupted upload](https://cloud.google.com/storage/docs/json_api/v1/how-tos/resumable-upload#resume-upload). This PR changes the `Content-Range` header to match the resuming protocol.

Closes #11 