### PR TITLE
respect a given offset when resuming

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ function Upload (cfg) {
   this.file = cfg.file
   this.generation = cfg.generation
   this.metadata = cfg.metadata || {}
+  this.offset = cfg.offset
   this.origin = cfg.origin
 
   this.predefinedAcl = cfg.predefinedAcl
@@ -55,9 +56,6 @@ function Upload (cfg) {
   this.numBytesWritten = 0
   this.numRetries = 0
 
-  cfg.offset = parseInt(cfg.offset, 10)
-  cfg.offset = isNaN(cfg.offset) ? 0 : cfg.offset
-
   var contentLength = cfg.metadata ? parseInt(cfg.metadata.contentLength, 10) : NaN
   this.contentLength = isNaN(contentLength) ? '*' : contentLength
 
@@ -69,7 +67,7 @@ function Upload (cfg) {
         if (err) return self.destroy(err)
         self.uri = uri
         self.set({ uri: uri })
-        self.offset = cfg.offset
+        self.offset = 0
         self.startUploading()
       })
     }
@@ -124,6 +122,7 @@ Upload.prototype.createURI = function (callback) {
 }
 
 Upload.prototype.continueUploading = function () {
+  if (typeof this.offset === 'number') return this.startUploading()
   this.getAndSetOffset(this.startUploading.bind(this))
 }
 

--- a/test.js
+++ b/test.js
@@ -310,19 +310,11 @@ describe('gcs-resumable-upload', function () {
         up.emit('writing')
       })
 
-      it('should set the offset if it is provided', function (done) {
-        var OFFSET = 10
-        var up = upload({ bucket: BUCKET, file: FILE, offset: OFFSET })
-        up.startUploading = function () {
-          assert.strictEqual(up.offset, OFFSET)
-          done()
-        }
+      it('should set the offset if it is provided', function () {
+        var offset = 10
+        var up = upload({ bucket: BUCKET, file: FILE, offset: offset })
 
-        up.createURI = function (callback) {
-          callback(null, URI)
-        }
-
-        up.emit('writing')
+        assert.strictEqual(up.offset, offset)
       })
     })
   })
@@ -393,7 +385,17 @@ describe('gcs-resumable-upload', function () {
   })
 
   describe('#continueUploading', function () {
-    it('should get and set offset', function (done) {
+    it('should start uploading if an offset was set', function (done) {
+      up.offset = 0
+
+      up.startUploading = function () {
+        done()
+      }
+
+      up.continueUploading()
+    })
+
+    it('should get and set offset if no offset was set', function (done) {
       up.getAndSetOffset = function () {
         done()
       }


### PR DESCRIPTION
Considering the following case:

-- I provide a resumable upload URI
-- I provide an offset

We were overwriting that in [`continueUploading`](https://github.com/stephenplusplus/gcs-resumable-upload/blob/700d60b26a96b465140bd79cb2135f772842017a/index.js#L127). That function is called as soon as data is written to the gcs-resumable-upload stream (https://github.com/stephenplusplus/gcs-resumable-upload/blob/700d60b26a96b465140bd79cb2135f772842017a/index.js#L64-L66). Within `continueUploading`, it always gets the offset from the API, and ends up overwriting what the user gave.

@bhstahl could you let me know if I'm wrong about any of that ^^ and if this change doesn't break anything. Thanks!