### PR TITLE
Update request and google-auto-auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+node_modules
 key.json

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "dependencies": {
     "buffer-equal": "^1.0.0",
     "configstore": "^3.0.0",
-    "google-auto-auth": "^0.6.0",
+    "google-auto-auth": "^0.7.1",
     "pumpify": "^1.3.3",
-    "request": "^2.61.0",
+    "request": "^2.81.0",
     "stream-events": "^1.0.1",
     "through2": "^2.0.0"
   },


### PR DESCRIPTION
Updates dependencies that allow tunnel-agent <= 0.6.0, which has a memory exposure vuln.