### PR TITLE
Use bucket/file for configStore key

### DIFF
--- a/index.js
+++ b/index.js
@@ -325,16 +325,16 @@ Upload.prototype.restart = function () {
 }
 
 Upload.prototype.get = function (prop) {
-  var store = this.configStore.get(this.file)
+  var store = this.configStore.get([this.bucket, this.file].join('/'))
   return store && store[prop]
 }
 
 Upload.prototype.set = function (props) {
-  this.configStore.set(this.file, props)
+  this.configStore.set([this.bucket, this.file].join('/'), props)
 }
 
 Upload.prototype.deleteConfig = function () {
-  this.configStore.delete(this.file)
+  this.configStore.delete([this.bucket, this.file].join('/'))
 }
 
 /**

--- a/test.js
+++ b/test.js
@@ -259,7 +259,7 @@ describe('gcs-resumable-upload', function () {
       assert.strictEqual(upWithUri.uriProvidedManually, true)
       assert.strictEqual(upWithUri.uri, uri)
 
-      configData[FILE] = { uri: 'fake-uri' }
+      configData[[BUCKET, FILE].join('/')] = { uri: 'fake-uri' }
       var up = upload({ bucket: BUCKET, file: FILE })
       assert.strictEqual(up.uriProvidedManually, false)
       assert.strictEqual(up.uri, 'fake-uri')
@@ -1167,7 +1167,8 @@ describe('gcs-resumable-upload', function () {
 
       up.configStore = {
         get: function (name) {
-          assert.strictEqual(name, up.file)
+          let actualKey = [up.bucket, up.file].join('/')
+          assert.strictEqual(name, actualKey)
 
           var obj = {}
           obj[prop] = value
@@ -1185,7 +1186,8 @@ describe('gcs-resumable-upload', function () {
 
       up.configStore = {
         set: function (name, prps) {
-          assert.strictEqual(name, up.file)
+          let actualKey = [up.bucket, up.file].join('/')
+          assert.strictEqual(name, actualKey)
           assert.strictEqual(prps, props)
           done()
         }
@@ -1201,7 +1203,8 @@ describe('gcs-resumable-upload', function () {
 
       up.configStore = {
         delete: function (name) {
-          assert.strictEqual(name, up.file)
+          let actualKey = [up.bucket, up.file].join('/')
+          assert.strictEqual(name, actualKey)
           done()
         }
       }


### PR DESCRIPTION
This fixes issues when using resumable uploads targeted towards
different buckets. The resumable URI will be for the wrong bucket if
there's an in-progress upload to a different bucket with the same
filename.