### PR TITLE
circle: run tests even if key decrypt failed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,11 @@ install_and_test: &install_and_test
     - run:
         name: Install
         command: npm install
+        when: always
     - run:
         name: Test
         command: npm test
+        when: always
         environment:
           GOOGLE_APPLICATION_CREDENTIALS: /root/project/.circleci/key.json
     - run:


### PR DESCRIPTION
RE: https://github.com/stephenplusplus/gcs-resumable-upload/pull/34#issuecomment-378684678

In Circle, we use an encrypted env var to decode the JSON key file. It is not exposed to forked PRs, thus Circle doesn't even try to run the tests when the key decryption step fails.

This is a temporary solution to simply always run the test commands, even when the decrypt fails. Having some failing tests (the ones that use the service account) is okay-- we'll at least see if any other new bugs were introduced.

After #34 / when it is convenient to start messing with code (don't want to interrupt what @JustinBeckwith is going through), I'll find a better way to do this, possibly a simple `if (/* is CirclePR */) { skip test }`