### PR TITLE
chore: remove buffer-equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "author": "Stephen Sawchuk <sawchuk@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "buffer-equal": "^1.0.0",
     "configstore": "^3.1.2",
     "google-auto-auth": "^0.10.0",
     "pumpify": "^1.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ import * as r from 'request';
 import { Stream } from 'stream';
 
 const StreamEvents = require('stream-events');
-const bufferEqual = require('buffer-equal');
 const googleAuth = require('google-auto-auth');
 const Pumpify = require('pumpify');
 
@@ -284,7 +283,7 @@ Upload.prototype.onChunk = function (chunk: string, enc: string, next: (err: Err
       cachedFirstChunk = Buffer.from(cachedFirstChunk);
       firstChunk = Buffer.from(firstChunk);
 
-      if (!bufferEqual(cachedFirstChunk, firstChunk)) {
+      if (Buffer.compare(cachedFirstChunk, firstChunk) !== 0) {
         // this data is not the same. start a new upload
         this.bufferStream.unshift(chunk);
         this.bufferStream.unpipe(this.offsetStream);

--- a/test/test.ts
+++ b/test/test.ts
@@ -9,8 +9,6 @@ import * as through from 'through2';
 
 import {Request, RequestBody, RequestResponse} from '../src';
 
-const bufferEqual = require('buffer-equal');
-
 let configData = {} as {[index: string]: {}};
 function ConfigStore() {
   this.delete = (key: string) => {
@@ -506,13 +504,11 @@ describe('gcs-resumable-upload', () => {
         it('should save the uri and first chunk if its not cached', () => {
           const URI = 'uri';
           up.uri = URI;
-
-          up.set = (props: {uri?: string, firstChunk?: string}) => {
-            const firstChunk = CHUNK.slice(0, 16).valueOf();
+          up.set = (props: {uri?: string, firstChunk: Buffer}) => {
+            const firstChunk = CHUNK.slice(0, 16);
             assert.deepEqual(props.uri, URI);
-            assert.strictEqual(bufferEqual(props.firstChunk, firstChunk), true);
+            assert.strictEqual(Buffer.compare(props.firstChunk, firstChunk), 0);
           };
-
           up.onChunk(CHUNK, ENC, NEXT);
         });
       });
@@ -564,11 +560,11 @@ describe('gcs-resumable-upload', () => {
       it('should slice the chunk by the offset - numBytesWritten', (done) => {
         const OFFSET = 8;
         up.offset = OFFSET;
-        up.onChunk(CHUNK, ENC, (err: Error, chunk: string) => {
+        up.onChunk(CHUNK, ENC, (err: Error, chunk: Buffer) => {
           assert.ifError(err);
 
           const expectedChunk = CHUNK.slice(OFFSET);
-          assert.strictEqual(bufferEqual(chunk, expectedChunk), true);
+          assert.strictEqual(Buffer.compare(chunk, expectedChunk), 0);
           done();
         });
       });


### PR DESCRIPTION
Turns out you don't need this with Node.js 4 and up 😸 