### PR TITLE
test: use nock for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@types/is-stream": "^1.1.0",
     "@types/mocha": "^5.0.0",
     "@types/mockery": "^1.4.29",
+    "@types/nock": "^9.1.3",
     "@types/node": "^9.6.1",
     "@types/request": "^2.47.0",
     "@types/through2": "^2.0.33",
@@ -52,6 +53,7 @@
     "is-stream": "^1.1.0",
     "mocha": "^5.0.5",
     "mockery": "^2.1.0",
+    "nock": "^9.2.5",
     "source-map-support": "^0.5.4",
     "typescript": "~2.8.0"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ const pumpify = require('pumpify');
 export type RequestBody = any;
 export type RequestResponse = r.Response;
 export type Request = r.Request;
+export type RequestOptions = r.OptionsWithUri;
+export type RequestCallback =
+    (err: Error|null, response?: r.Response, body?: RequestBody) => void;
+export type AuthorizeRequestCallback =
+    (err: Error|null, authorizedReqOpts: RequestOptions) => void;
 
 const request = r.defaults({json: true, pool: {maxSockets: Infinity}});
 
@@ -181,7 +186,7 @@ Upload.prototype.createURI = function(
     callback: (err: Error|null, uri?: string) => void) {
   const metadata = this.metadata;
 
-  const reqOpts: r.Options = {
+  const reqOpts: RequestOptions = {
     method: 'POST',
     uri: [BASE_URI, this.bucket, 'o'].join('/'),
     qs: {name: this.file, uploadType: 'resumable'},
@@ -209,7 +214,7 @@ Upload.prototype.createURI = function(
     reqOpts.headers!.Origin = this.origin;
   }
 
-  this.makeRequest(reqOpts, (err: Error, resp: r.RequestResponse) => {
+  this.makeRequest(reqOpts, (err: Error, resp: RequestResponse) => {
     if (err) {
       return callback(err);
     }
@@ -310,7 +315,7 @@ Upload.prototype.getAndSetOffset = function(callback: () => void) {
         uri: this.uri,
         headers: {'Content-Length': 0, 'Content-Range': 'bytes */*'}
       },
-      (err: Error|null, resp: r.RequestResponse) => {
+      (err: Error|null, resp: RequestResponse) => {
         if (err) {
           // we don't return a 404 to the user if they provided the resumable
           // URI. if we're just using the configstore file to tell us that this
@@ -347,7 +352,7 @@ Upload.prototype.getAndSetOffset = function(callback: () => void) {
 };
 
 Upload.prototype.makeRequest = function(
-    reqOpts: r.Options, callback: r.RequestCallback) {
+    reqOpts: RequestOptions, callback: RequestCallback) {
   if (this.encryption) {
     reqOpts.headers = reqOpts.headers || {};
     reqOpts.headers['x-goog-encryption-algorithm'] = 'AES256';
@@ -361,7 +366,7 @@ Upload.prototype.makeRequest = function(
   }
 
   this.authClient.authorizeRequest(
-      reqOpts, (err: Error, authorizedReqOpts: r.Options) => {
+      reqOpts, (err: Error, authorizedReqOpts: RequestOptions) => {
         if (err) {
           err = wrapError('Could not authenticate request', err);
           return callback(err, null!, null);
@@ -389,14 +394,14 @@ Upload.prototype.makeRequest = function(
 };
 
 Upload.prototype.getRequestStream = function(
-    reqOpts: r.Options, callback: (requestStream: r.Request) => void) {
+    reqOpts: RequestOptions, callback: (requestStream: Request) => void) {
   if (this.userProject) {
     reqOpts.qs = reqOpts.qs || {};
     reqOpts.qs.userProject = this.userProject;
   }
 
   this.authClient.authorizeRequest(
-      reqOpts, (err: Error, authorizedReqOpts: r.Options) => {
+      reqOpts, (err: Error, authorizedReqOpts: RequestOptions) => {
         if (err) {
           return this.destroy(wrapError('Could not authenticate request', err));
         }
@@ -444,7 +449,7 @@ Upload.prototype.deleteConfig = function() {
 /**
  * @return {bool} is the request good?
  */
-Upload.prototype.onResponse = function(resp: r.RequestResponse) {
+Upload.prototype.onResponse = function(resp: RequestResponse) {
   if (resp.statusCode === 404) {
     if (this.numRetries < RETRY_LIMIT) {
       this.numRetries++;


### PR DESCRIPTION
This is going to be important when we look at switching to axios.  This switches up a few of the tests to use nock instead of stubbing `request` calls.  It also standardizes the types used for Request type stuff, meaning less churn in the tests when we change stuff. 