### PR TITLE
fix: quarantine axios types

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-
-import {upload, RequestResponse} from '.';
+import {upload} from '.';
 
 const args = process.argv.slice(2);
 const opts = {
@@ -10,7 +9,7 @@ const opts = {
 
 process.stdin.pipe(upload(opts))
     .on('error', console.error)
-    .on('response', (resp: RequestResponse, metadata: {mediaLink: string}) => {
+    .on('response', (resp, metadata) => {
       if (!metadata || !metadata.mediaLink) return;
       console.log('uploaded!');
       console.log(metadata.mediaLink);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,21 +1,13 @@
 import {AxiosError, AxiosRequestConfig, AxiosResponse} from 'axios';
 import ConfigStore from 'configstore';
-import * as crypto from 'crypto';
+import {createHash} from 'crypto';
 import {GoogleAuth, GoogleAuthOptions} from 'google-auth-library';
 import Pumpify from 'pumpify';
 import r from 'request';
 import {PassThrough} from 'stream';
 import streamEvents from 'stream-events';
 
-// tslint:disable-next-line no-any
-export type RequestBody = any;
-export type RequestResponse = AxiosResponse;
-export type Request = r.Request;
-export type RequestOptions = AxiosRequestConfig;
-export type RequestCallback =
-    (err: Error|null, response?: AxiosResponse, body?: RequestBody) => void;
-export type AuthorizeRequestCallback =
-    (err: Error|null, authorizedReqOpts: RequestOptions) => void;
+import {RequestCallback, RequestOptions, RequestResponse} from './types';
 
 const request = r.defaults({json: true, pool: {maxSockets: Infinity}});
 
@@ -191,7 +183,7 @@ export class Upload extends Pumpify {
       const base64Key = Buffer.from(cfg.key as string).toString('base64');
       this.encryption = {
         key: base64Key,
-        hash: crypto.createHash('sha256').update(cfg.key).digest('base64')
+        hash: createHash('sha256').update(cfg.key).digest('base64')
       };
     }
 
@@ -291,7 +283,7 @@ export class Upload extends Pumpify {
         new PassThrough({transform: this.onChunk.bind(this)});
     const delayStream = new PassThrough();
 
-    this.getRequestStream(reqOpts, (requestStream: Request) => {
+    this.getRequestStream(reqOpts, (requestStream: r.Request) => {
       this.setPipeline(bufferStream, offsetStream, requestStream, delayStream);
 
       // wait for "complete" from request before letting the stream finish
@@ -425,7 +417,7 @@ export class Upload extends Pumpify {
   }
 
   private getRequestStream(
-      reqOpts: RequestOptions, callback: (requestStream: Request) => void) {
+      reqOpts: RequestOptions, callback: (requestStream: r.Request) => void) {
     if (this.userProject) {
       reqOpts.params = reqOpts.params || {};
       reqOpts.params.userProject = this.userProject;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,8 @@
+import {AxiosRequestConfig, AxiosResponse} from 'axios';
+
+// tslint:disable-next-line no-any
+export type RequestBody = any;
+export type RequestResponse = AxiosResponse;
+export type RequestOptions = AxiosRequestConfig;
+export type RequestCallback =
+    (err: Error|null, response?: AxiosResponse, body?: RequestBody) => void;

--- a/test/system-tests/kitchen.ts
+++ b/test/system-tests/kitchen.ts
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import * as fs from 'fs';
 
-import {createURI, RequestResponse, upload} from '../../src';
+import {createURI, upload} from '../../src';
 
 const bucketName = process.env.BUCKET_NAME!;
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -8,7 +8,9 @@ import * as path from 'path';
 import * as stream from 'stream';
 import through from 'through2';
 import * as url from 'url';
-import {RequestBody, RequestCallback, RequestOptions, RequestResponse} from '../src';
+
+import {CreateUriCallback} from '../src';
+import {RequestBody, RequestCallback, RequestOptions, RequestResponse} from '../src/types';
 
 const dawPath = path.join(__dirname, '../../daw.jpg');
 
@@ -194,8 +196,8 @@ describe('gcs-resumable-upload', () => {
 
       it('should create an upload', (done) => {
         up.startUploading = done;
-        up.createURI = (callback: RequestCallback) => {
-          callback(null, null!, null);
+        up.createURI = (callback: CreateUriCallback) => {
+          callback(null);
         };
         up.emit('writing');
       });
@@ -206,8 +208,8 @@ describe('gcs-resumable-upload', () => {
           assert(err.message.indexOf(error.message) > -1);
           done();
         };
-        up.createURI = (callback: RequestCallback) => {
-          callback(error, null!, null);
+        up.createURI = (callback: CreateUriCallback) => {
+          callback(error);
         };
         up.emit('writing');
       });


### PR DESCRIPTION
This change makes sure that `axios` types don't leak into the `index.d.ts`. 