### PR TITLE
test: preserve original path in tests

### DIFF
--- a/test/test.ts
+++ b/test/test.ts
@@ -887,7 +887,7 @@ describe('gcs-resumable-upload', () => {
         nock(REQ_OPTS.url!).get(queryPath).reply(200, {}),
       ];
       const res: GaxiosResponse = await up.makeRequest(REQ_OPTS);
-      assert.strictEqual(res.config.url, REQ_OPTS.url + queryPath);
+      assert.strictEqual(res.config.url, REQ_OPTS.url + queryPath.slice(1));
       scopes.forEach(x => x.done());
     });
 
@@ -919,7 +919,7 @@ describe('gcs-resumable-upload', () => {
       ];
       const res = await up.makeRequest(REQ_OPTS);
       scopes.forEach(x => x.done());
-      assert.strictEqual(res.config.url, REQ_OPTS.url + queryPath);
+      assert.strictEqual(res.config.url, REQ_OPTS.url + queryPath.slice(1));
       assert.deepStrictEqual(res.headers, {});
     });
 


### PR DESCRIPTION
Test change only, unblocking failing unit tests on default branch.  I suspect this is a side effect of the fix in https://github.com/googleapis/gaxios/pull/357, which ensured more strict adherence to preserving the original querystring during requests.  