### PR TITLE
fix: createURI() should not persist uri

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -310,10 +310,11 @@ export class Upload extends Pumpify {
       if (this.uri) {
         this.continueUploading();
       } else {
-        this.createURI(err => {
+        this.createURI((err, uri) => {
           if (err) {
             return this.destroy(err);
           }
+          this.set({uri});
           this.startUploading();
         });
       }
@@ -374,7 +375,6 @@ export class Upload extends Pumpify {
     const resp = await this.makeRequest(reqOpts);
     const uri = resp.headers.location;
     this.uri = uri;
-    this.set({uri});
     this.offset = 0;
     return uri;
   }
@@ -614,10 +614,11 @@ export class Upload extends Pumpify {
     this.emit('restart');
     this.numBytesWritten = 0;
     this.deleteConfig();
-    this.createURI(err => {
+    this.createURI((err, uri) => {
       if (err) {
         return this.destroy(err);
       }
+      this.set({uri});
       this.startUploading();
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,8 +348,9 @@ export class Upload extends Pumpify {
     };
 
     if (metadata.contentLength) {
-      reqOpts.headers!['X-Upload-Content-Length'] =
-        metadata.contentLength.toString();
+      reqOpts.headers![
+        'X-Upload-Content-Length'
+      ] = metadata.contentLength.toString();
     }
 
     if (metadata.contentType) {
@@ -559,8 +560,9 @@ export class Upload extends Pumpify {
       reqOpts.headers = reqOpts.headers || {};
       reqOpts.headers['x-goog-encryption-algorithm'] = 'AES256';
       reqOpts.headers['x-goog-encryption-key'] = this.encryption.key.toString();
-      reqOpts.headers['x-goog-encryption-key-sha256'] =
-        this.encryption.hash.toString();
+      reqOpts.headers[
+        'x-goog-encryption-key-sha256'
+      ] = this.encryption.hash.toString();
     }
 
     if (this.userProject) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,9 +348,8 @@ export class Upload extends Pumpify {
     };
 
     if (metadata.contentLength) {
-      reqOpts.headers![
-        'X-Upload-Content-Length'
-      ] = metadata.contentLength.toString();
+      reqOpts.headers!['X-Upload-Content-Length'] =
+        metadata.contentLength.toString();
     }
 
     if (metadata.contentType) {
@@ -560,9 +559,8 @@ export class Upload extends Pumpify {
       reqOpts.headers = reqOpts.headers || {};
       reqOpts.headers['x-goog-encryption-algorithm'] = 'AES256';
       reqOpts.headers['x-goog-encryption-key'] = this.encryption.key.toString();
-      reqOpts.headers[
-        'x-goog-encryption-key-sha256'
-      ] = this.encryption.hash.toString();
+      reqOpts.headers['x-goog-encryption-key-sha256'] =
+        this.encryption.hash.toString();
     }
 
     if (this.userProject) {

--- a/test/test.ts
+++ b/test/test.ts
@@ -322,6 +322,18 @@ describe('gcs-resumable-upload', () => {
         };
         up.emit('writing');
       });
+
+      it('should save the uri to config', done => {
+        const uri = 'http://newly-created-uri';
+        up.createURI = (callback: CreateUriCallback) => {
+          callback(null, uri);
+        };
+        up.set = (props: {}) => {
+          assert.deepStrictEqual(props, {uri});
+          done();
+        };
+        up.emit('writing');
+      });
     });
   });
 
@@ -401,15 +413,6 @@ describe('gcs-resumable-upload', () => {
           assert.strictEqual(up.offset, 0);
           done();
         });
-      });
-
-      it('should save the uri to config', done => {
-        up.set = (props: {}) => {
-          assert.deepStrictEqual(props, {uri: URI});
-          done();
-        };
-
-        up.createURI(assert.ifError);
       });
 
       it('should default the offset to 0', done => {
@@ -1164,6 +1167,21 @@ describe('gcs-resumable-upload', () => {
 
         up.destroy = (err: Error) => {
           assert.strictEqual(err, error);
+          done();
+        };
+
+        up.restart();
+      });
+
+      it('should save the uri to config', done => {
+        const uri = 'http://newly-created-uri';
+
+        up.createURI = (callback: Function) => {
+          callback(null, uri);
+        };
+
+        up.set = (props: {}) => {
+          assert.deepStrictEqual(props, {uri});
           done();
         };
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -323,7 +323,7 @@ describe('gcs-resumable-upload', () => {
         up.emit('writing');
       });
 
-      it('should save the uri to config', done => {
+      it('should save the uri to config on first write event', done => {
         const uri = 'http://newly-created-uri';
         up.createURI = (callback: CreateUriCallback) => {
           callback(null, uri);
@@ -1173,7 +1173,7 @@ describe('gcs-resumable-upload', () => {
         up.restart();
       });
 
-      it('should save the uri to config', done => {
+      it('should save the uri to config when restarting', done => {
         const uri = 'http://newly-created-uri';
 
         up.createURI = (callback: Function) => {


### PR DESCRIPTION
Fixes https://github.com/googleapis/nodejs-storage/issues/1489

When a user uploads a file, we internally call "createURI()" to generate the resumable upload URI. We realized later that users might just need the URI, but not want to upload a file with this library. So, we exposed the function publicly.

We left behind an internal implementation detail, though, which had a side effect. We use `ConfigStore` to persist the URI, so that during an interrupted upload, we can pick up where we left off with the data we cached. As https://github.com/googleapis/nodejs-storage/issues/1489 points out, that's not something they need, and it's been using up disk space.

To fix the issue, we will only persist the URI during a deliberate upload attempt. Otherwise, we will simply return the URI.