### PR TITLE
fix: throw informative error in the case that retries run out

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -448,7 +448,7 @@ export class Upload extends Pumpify {
             this.retryableErrorFn &&
             this.retryableErrorFn!(apiError)
           ) {
-            throw new Error();
+            throw e;
           } else {
             return bail(e);
           }


### PR DESCRIPTION
Realized that if retries run out, the `throw Error` section will actually throw and bubble up to the user.