### PR TITLE
fix: Fix support for streams without content-length property

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -393,6 +393,10 @@ export class Upload extends Pumpify {
       this.upstreamEnded = true;
     });
 
+    this.on('prefinish', () => {
+      this.upstreamEnded = true;
+    });
+
     this.once('writing', () => {
       // Now that someone is writing to this object, let's attach
       // some duplexes. These duplexes enable this object to be
@@ -517,6 +521,7 @@ export class Upload extends Pumpify {
       const removeListeners = () => {
         this.removeListener('wroteToChunkBuffer', wroteToChunkBufferCallback);
         this.upstream.removeListener('finish', upstreamFinishedCallback);
+        this.removeListener('prefinish', upstreamFinishedCallback);
       };
 
       // If there's data recently written it should be digested
@@ -524,6 +529,7 @@ export class Upload extends Pumpify {
 
       // If the upstream finishes let's see if there's anything to grab
       this.upstream.once('finish', upstreamFinishedCallback);
+      this.once('prefinish', upstreamFinishedCallback);
     });
 
     return willBeMoreChunks;


### PR DESCRIPTION
In `pumpify` the `prefinish` event is emitted when an upstream writer has ended, not `end` (as with standard streams).

Fixes #490 🦕
